### PR TITLE
feat(viewmodel): Sanitize postcode input before API call and validate results across formats #23

### DIFF
--- a/app/src/main/java/com/sadaquekhan/justeatassessment/ui/screen/RestaurantScreen.kt
+++ b/app/src/main/java/com/sadaquekhan/justeatassessment/ui/screen/RestaurantScreen.kt
@@ -33,11 +33,9 @@ fun RestaurantScreen(viewModel: RestaurantViewModel) {
             },
             onSearch = {
                 if (postcode.trim().length >= 5) {
-                    Log.d("RestaurantScreen", "Triggering search for postcode: $postcode")
-                    viewModel.loadRestaurants(postcode.trim().uppercase())
+                    viewModel.loadRestaurants(postcode) // ViewModel handles sanitization
                     showError = false
                 } else {
-                    Log.d("RestaurantScreen", "Invalid postcode input: $postcode")
                     showError = true
                 }
             }

--- a/app/src/main/java/com/sadaquekhan/justeatassessment/viewmodel/RestaurantViewModel.kt
+++ b/app/src/main/java/com/sadaquekhan/justeatassessment/viewmodel/RestaurantViewModel.kt
@@ -19,14 +19,16 @@ class RestaurantViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(RestaurantUiState())
     val uiState: StateFlow<RestaurantUiState> = _uiState
 
-    fun loadRestaurants(postcode: String) {
+    fun loadRestaurants(rawPostcode: String) {
+        // Sanitize the postcode: trim, remove spaces, uppercase
+        val sanitized = rawPostcode.replace("\\s".toRegex(), "").uppercase()
+
+        Log.d("RestaurantViewModel", "Loading restaurants for postcode: $sanitized")
+
         viewModelScope.launch {
-            Log.d("RestaurantViewModel", "Loading restaurants for postcode: $postcode")
             _uiState.value = _uiState.value.copy(isLoading = true)
 
-            val restaurants: List<Restaurant> = repository.getRestaurants(postcode)
-
-            Log.d("RestaurantViewModel", "Fetched ${restaurants.size} restaurants from repository")
+            val restaurants: List<Restaurant> = repository.getRestaurants(sanitized)
 
             _uiState.value = _uiState.value.copy(
                 restaurants = restaurants,


### PR DESCRIPTION
## 📌 Summary

This PR finalizes the sanitation logic for postcode input before initiating the API call.  
It ensures users can enter postcodes in **any common format ➝ cleaned ➝ valid API request ➝ consistent restaurant results**, supporting various edge cases and improving overall robustness.

---

## ✅ What’s Implemented

- `SearchBar` – accepts user input with flexible formats
- `RestaurantViewModel` – sanitizes postcode via `.trim().uppercase()` before sending to repository
- `RestaurantScreen` – cleaned up by delegating sanitation responsibility to the ViewModel
- Validated multiple formats (`nw64ju`, ` NW6 4JU `, `NW6 4ju`) across emulator and physical device
- Ensured no regression in rendering fetched results

---

## 🔗 Issue Reference

Closes 📘 **[STORY] Sanitize postcode input before API call #23**

No sub-tasks linked to this story